### PR TITLE
added parsing support for meta properties as key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ npm install lets-get-meta --save
 ```js
 var getMeta = require("lets-get-meta")
 
-// Pass and HTML string
-getMeta("<meta name='page' content='index'><meta name='description' content='This is the index page'>")
+// Pass an HTML string that includes name and/or property metatags
+getMeta("<meta name='page' content='index'><meta property='description' content='This is the index page'>")
 
 // Get back an object
 {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ var letsGetMeta = module.exports = function(input) {
   var $ = cheerio.load(input)
   var meta = {}
   $("meta").each(function(i, tag){
-    var k = $(this).attr('name')
+    var n = $(this).attr('name')
+    var p = $(this).attr('property')
+    var k = n ? n : p
     var v = $(this).attr('content')
     if (k && v) meta[k] = v
   })

--- a/index.js
+++ b/index.js
@@ -4,10 +4,8 @@ var letsGetMeta = module.exports = function(input) {
   var $ = cheerio.load(input)
   var meta = {}
   $("meta").each(function(i, tag){
-    var n = $(this).attr('name')
-    var p = $(this).attr('property')
-    var k = n ? n : p
-    var v = $(this).attr('content')
+    var k = $(this).attr('name') || $(this).attr('property')
+    var v = $(this).attr('content')  
     if (k && v) meta[k] = v
   })
   return meta

--- a/test/fixtures/simple.html
+++ b/test/fixtures/simple.html
@@ -1,2 +1,3 @@
 <meta name="foo" content="yes">
 <meta name="bar" content="no">
+<meta property="og:title" content="page title">

--- a/test/fixtures/undesirable.html
+++ b/test/fixtures/undesirable.html
@@ -1,3 +1,5 @@
 <meta content="I am missing a name attribute">
 <meta name="And I am missing a content attribute">
 <meta name="only" content="one">
+<meta property="irrelevant and without content">
+

--- a/test/index.js
+++ b/test/index.js
@@ -12,10 +12,11 @@ fs.readdirSync(__dirname + "/fixtures").forEach(function(file) {
 
 describe("lets-get-meta", function() {
 
-  it("extracts name and content from meta tags in an HTML string and returns a key-value object", function() {
+  it("extracts name or property and its content from meta tags in an HTML string and returns a key-value object", function() {
     assert.deepEqual(m(fixtures.simple), {
       foo: "yes",
-      bar: "no"
+      bar: "no",
+      'og:title': 'page title'
     })
   })
 


### PR DESCRIPTION
adds support for parsing `<meta property="" content="">` to the meta object. 
e.g. pages with facebook and twitter support use these.