### PR TITLE
Upgrade (dev)dependencies to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "homepage": "https://github.com/zeke/lets-get-meta",
   "dependencies": {
-    "cheerio": "^0.17.0"
+    "cheerio": "^0.22.0"
   },
   "devDependencies": {
-    "mocha": "^1.21.4"
+    "mocha": "^3.2.0"
   }
 }


### PR DESCRIPTION
Upgrading `cheerio` avoids using the deprecated `CSSselect` (and `CSSwhat`)
packages in favor of `css-select` (and `css-what`). I thought I'd also
upgrade `mocha` while I was at it.